### PR TITLE
Update cluster-manual.md

### DIFF
--- a/docs/cluster-manual.md
+++ b/docs/cluster-manual.md
@@ -12,7 +12,7 @@ You can launch the clustering GUI from the session.
 
 ```python
 >>> import phy
->>> phy.enable_qt()
+>>> phy.gui.enable_qt()
 12:52:52 [I] Qt event loop activated.
 ```
 


### PR DESCRIPTION
## In [7]: phy.enable_qt()

AttributeError                            Traceback (most recent call last)
<ipython-input-7-48a314a7433c> in <module>()
----> 1 phy.enable_qt()

AttributeError: 'module' object has no attribute 'enable_qt'
